### PR TITLE
Feature/utrecht paragraph component

### DIFF
--- a/packages/storybook/src/css-utrecht-paragraph.stories.tsx
+++ b/packages/storybook/src/css-utrecht-paragraph.stories.tsx
@@ -1,0 +1,62 @@
+/* @license CC0-1.0 */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { Paragraph } from '@utrecht/component-library-react/dist/css-module';
+// import readme from 'paragraph.md?raw';
+
+const meta = {
+  title: 'CSS Component/Paragraph',
+  id: 'css-utrecht-paragraph',
+  component: Paragraph,
+  argTypes: {
+    children: {
+      name: 'Content',
+      type: {
+        name: 'string',
+        required: true,
+      },
+      defaultValue: '',
+    },
+  },
+  args: {
+    children: '',
+  },
+  tags: ['autodocs'],
+  parameters: {
+    bugs: 'https://github.com/nl-design-system/rotterdam/labels/component%2Fparagraph',
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/ZWSC4gCrOXRUR9UX3aoZ8x/?node-id=415-12136',
+    },
+    docs: {
+      description: {},
+    },
+  },
+} satisfies Meta<typeof Paragraph>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Paragraph',
+  args: {
+    children:
+      'Een geveltuin aanleggen is leuk om te doen, de straat knapt ervan op en uw huis blijft in de zomer koeler. Meer groen maakt de stad ook beter bestand tegen klimaatveranderingen en wateroverlast en is goed voor insecten en vogels. Een geveltuin is een strook planten tegen de gevel van een woning. Ze zijn vooral geschikt in straten waar de huizen geen voortuin hebben. Eén enkele klimplant, stokroos of zonnebloem maakt het straatbeeld al gezelliger, maar andere planten kunnen natuurlijk ook. U kiest zelf.',
+  },
+};
+export const LeadParagraph: Story = {
+  name: 'Lead paragraph',
+  args: {
+    ...Default.args,
+    lead: true,
+  },
+};
+
+export const SmallPrintParagraph: Story = {
+  name: 'Small print',
+  args: {
+    ...Default.args,
+    small: true,
+  },
+};

--- a/packages/storybook/src/css-utrecht-paragraph.stories.tsx
+++ b/packages/storybook/src/css-utrecht-paragraph.stories.tsx
@@ -23,11 +23,6 @@ const meta = {
   },
   tags: ['autodocs'],
   parameters: {
-    bugs: 'https://github.com/nl-design-system/rotterdam/labels/component%2Fparagraph',
-    design: {
-      type: 'figma',
-      url: 'https://www.figma.com/file/ZWSC4gCrOXRUR9UX3aoZ8x/?node-id=415-12136',
-    },
     docs: {
       description: {},
     },
@@ -42,7 +37,7 @@ export const Default: Story = {
   name: 'Paragraph',
   args: {
     children:
-      'Een geveltuin aanleggen is leuk om te doen, de straat knapt ervan op en uw huis blijft in de zomer koeler. Meer groen maakt de stad ook beter bestand tegen klimaatveranderingen en wateroverlast en is goed voor insecten en vogels. Een geveltuin is een strook planten tegen de gevel van een woning. Ze zijn vooral geschikt in straten waar de huizen geen voortuin hebben. Eén enkele klimplant, stokroos of zonnebloem maakt het straatbeeld al gezelliger, maar andere planten kunnen natuurlijk ook. U kiest zelf.',
+      'Herbruikbare componenten onafhankelijk van huisstijl, daar mag je ons voor wakker maken! Frameless heeft al aan meerdere white-label design systems mogen werken en is trots op onze bijdrage aan NL Design System. Wij helpen ook graag als technisch partner bij het bouwen van toegankelijke en gebruiksvriendelijke web applicaties.',
   },
 };
 export const LeadParagraph: Story = {


### PR DESCRIPTION
In deze PR

**css-utrecht-paragraph.stories.tsx**
* Utrecht Paragraph CSS Component geïmporteerd in Storybook 
* Implementatie van Rotterdam overgenomen en aangepast naar Frameless

**paragraph.md**
* Utrecht Paragraph CSS Component readme file aangemaakt (aanvullen vd inhoud is een taak voor later in het project)

**vraagje:**
Ik zag dat de heading componenten in storybook css-heading1.stories.tsx genoemd zijn, bij mij heb ik utrecht in de naamgeving gezet (utrecht-paragraph.stories.tsx). Ik zou het graag consistent houden. De mijne aanpassen lijkt me het minste werk maar ik heb in Rotterdam gezien dat zij utrecht wel benoemen. Wat zullen we afspreken voor Frameless?

Also, kan de paragraph.md file uit de Storybook folder? In het logo component heb ik de readme namelijk in het css component mapje gezet maar voor paragraph heeft deze geen eigen folder (bestaat alleen in Storybook).
