### PR TITLE
Refactor/storybook homepage template styling

### DIFF
--- a/packages/storybook/src/templates/homepage.scss
+++ b/packages/storybook/src/templates/homepage.scss
@@ -16,3 +16,9 @@ section:nth-of-type(1) {
   flex-direction: column;
   gap: 0.5em;
 }
+
+section:nth-of-type(3) {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}

--- a/packages/storybook/src/templates/homepage.scss
+++ b/packages/storybook/src/templates/homepage.scss
@@ -1,3 +1,18 @@
+.frameless-page-container {
+  container: framelesshomepage / inline-size;
+}
+
 .frameless-page {
-  container-type: inline-size;
+  display: flex;
+  flex-direction: column;
+  gap: 2em;
+  margin-block-end: var(--utrecht-page-margin-block-end);
+  margin-block-start: var(--utrecht-page-margin-block-start);
+  max-inline-size: var(--utrecht-page-max-inline-size);
+}
+
+section:nth-of-type(1) {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
 }

--- a/packages/storybook/src/templates/homepage.stories.tsx
+++ b/packages/storybook/src/templates/homepage.stories.tsx
@@ -1,16 +1,19 @@
 /* @license CC0-1.0 */
 
-// TODO: import { Logo } from '';
-// TODO: import { Card, CardGroup } from '';
+import { Card } from '@frameless/components-react/src/Card';
+import { CardGroup } from '@frameless/components-react/src/CardGroup';
+import { Logo } from '@frameless/components-react/src/Logo';
 import { Meta, StoryObj } from '@storybook/react';
 import {
   Heading2,
-  Heading3,
   Link,
+  Page,
+  PageContent,
   Paragraph,
   UnorderedList,
   UnorderedListItem,
 } from '@utrecht/component-library-react/dist/css-module';
+
 import './homepage.scss';
 
 const meta = {
@@ -25,106 +28,104 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: (args) => (
-    <div {...args} className="frameless-page">
-      {/* <Logo/> */}
+    <Page>
+      <PageContent>
+        <div {...args} className="frameless-page-container">
+          <Logo />
 
-      <section>
-        {/*About*/}
-        <Heading2>Wij Maken</Heading2>
+          <div className="frameless-page">
+            <section className="frameless-section__about">
+              <Heading2>Wij Maken</Heading2>
 
-        <div>
-          {/* //TODO: CardGroup*/}
-          <div>
-            {/* //TODO: Card*/}
-            <Heading3>Design Systems</Heading3>
-            <Paragraph>
-              Herbruikbare componenten onafhankelijk van huisstijl, daar mag je ons voor wakker maken!
-            </Paragraph>
-            <Paragraph>
-              Frameless heeft al aan meerdere white-label design systems mogen werken en is trots op onze bijdrage aan{' '}
-              <Link href="https://nldesignsystem.nl">NL Design System</Link>
-            </Paragraph>
-          </div>
+              <CardGroup>
+                <Card headingLevel={3} heading="Design Systems">
+                  <Paragraph>
+                    Herbruikbare componenten onafhankelijk van huisstijl, daar mag je ons voor wakker maken!
+                  </Paragraph>
+                  <Paragraph>
+                    Frameless heeft al aan meerdere white-label design systems mogen werken en is trots op onze bijdrage
+                    aan <Link href="https://nldesignsystem.nl">NL Design System</Link>
+                  </Paragraph>
+                </Card>
 
-          <div>
-            {/* //TODO: Card*/}
-            <Heading3>Front-ends</Heading3>
-            <Paragraph>
-              Wij helpen graag als technisch partner bij het bouwen van toegankelijke en gebruiksvriendelijke web
-              applicaties.
-            </Paragraph>
+                <Card headingLevel={3} heading="Front-ends">
+                  <Paragraph>
+                    Wij helpen graag als technisch partner bij het bouwen van toegankelijke en gebruiksvriendelijke web
+                    applicaties.
+                  </Paragraph>
+                </Card>
+              </CardGroup>
+            </section>
+
+            <section className="frameless-section__contact">
+              <Heading2>Kennis maken?</Heading2>
+              <Paragraph>
+                Mail ons op
+                <Link href="mailto:hello@frameless.io"> hello@frameless.io</Link>, dan spreken we snel een keer af!
+              </Paragraph>
+            </section>
+
+            <section className="frameless-section__projecten">
+              <Heading2>Goed voor elkaar</Heading2>
+              <Paragraph>
+                Afgelopen tijd hebben Robbert, Yolijn, Ali, Savi, Rowan, Tessa, Marwa, Angela en Bryan aan veel leuke
+                projecten gewerkt:
+              </Paragraph>
+
+              <UnorderedList>
+                <UnorderedListItem>
+                  <Link href="https://nldesignsystem.nl/">NL Design System</Link>: Yolijn en Robbert zijn sinds 2020
+                  verantwoordelijk voor de architectuur, community en groei van NL Design System.
+                </UnorderedListItem>
+
+                <UnorderedListItem>
+                  <Link href="https://nl-design-system.github.io/utrecht/storybook/">Utrecht Design System</Link>: meer
+                  dan 80 componenten ontwikkeld voor Utrecht in verschillende technieken: als CSS, HTML, React, Angular,
+                  Vue en als Web Component. Deze componenten worden inmiddels ook veel gebruikt door uiteenlopende
+                  projecten in de NL Design System community.
+                </UnorderedListItem>
+
+                <UnorderedListItem>
+                  <Link href="https://nl-design-system.github.io/denhaag/"> Den Haag Design System</Link>: begeleiding
+                  van het design system team, en leveranciers begeleiden met open source bouwen volgens de NL Design
+                  System architectuur.
+                </UnorderedListItem>
+
+                <UnorderedListItem>
+                  <Link href="https://pki.utrecht.nl/">Digitaal Loket van gemeente Utrecht</Link>: ontwikkeling van
+                  Strapi CMS voor de Producten en Diensten Catalogus, en de nieuwe website ontwikkelen als headless
+                  frontend op basis van NL Design System. Dit project wordt in de loop van 2024 zichtbaar op utrecht.nl.
+                </UnorderedListItem>
+
+                <UnorderedListItem>
+                  Huwelijksplanner voor gemeente Utrecht: front-end ontwikkeling Huwelijksplanner CMS op basis van NL
+                  Design System componenten.
+                </UnorderedListItem>
+
+                <UnorderedListItem>
+                  <Link href="https://gemeentevoorbeeld.nl/">gemeente Voorbeeld</Link>: ontwikkeling van demo-website
+                  waar Vereniging van Nederlandse Gemeenten (VNG) gebruikerstesten doet, om gemeenten op weg te helpen
+                  met voldoen aan de&#160;
+                  <Link href="https://www.digitaleoverheid.nl/overzicht-van-alle-onderwerpen/wetgeving/wet-modernisering-elektronisch-bestuurlijk-verkeer/">
+                    WMEBV
+                  </Link>
+                  &#160;met NL Design System.
+                </UnorderedListItem>
+
+                <UnorderedListItem>
+                  <Link href="https://opencatalogi.nl/">OpenCatalogi.nl — migratie naar NL Design System</Link>:
+                  migratie van codebase naar React componenten uit de NL Design System community.
+                </UnorderedListItem>
+
+                <UnorderedListItem>
+                  <Link href="https://opencatalogi.nl/">Huisstijl van gemeente Rotterdam voor OpenCatalogi.nl</Link>:
+                  ontwikkeling van NL Design System thema zodat OpenCatalogi kan overstappen op NL Design System.
+                </UnorderedListItem>
+              </UnorderedList>
+            </section>
           </div>
         </div>
-      </section>
-
-      <section>
-        {/*Contact*/}
-        <Heading2>Kennis maken?</Heading2>
-        <Paragraph>
-          Mail ons op
-          <Link href="mailto:hello@frameless.io"> hello@frameless.io</Link>, dan spreken we snel een keer af!
-        </Paragraph>
-      </section>
-
-      <section>
-        {/*Projecten*/}
-        <Heading2>Goed voor elkaar</Heading2>
-        <Paragraph>
-          Afgelopen tijd hebben Robbert, Yolijn, Ali, Savi, Rowan, Tessa, Marwa, Angela en Bryan aan veel leuke
-          projecten gewerkt:
-        </Paragraph>
-
-        <UnorderedList>
-          <UnorderedListItem>
-            <Link href="https://nldesignsystem.nl/">NL Design System</Link>: Yolijn en Robbert zijn sinds 2020
-            verantwoordelijk voor de architectuur, community en groei van NL Design System.
-          </UnorderedListItem>
-
-          <UnorderedListItem>
-            <Link href="https://nl-design-system.github.io/utrecht/storybook/">Utrecht Design System</Link>: meer dan 80
-            componenten ontwikkeld voor Utrecht in verschillende technieken: als CSS, HTML, React, Angular, Vue en als
-            Web Component. Deze componenten worden inmiddels ook veel gebruikt door uiteenlopende projecten in de NL
-            Design System community.
-          </UnorderedListItem>
-
-          <UnorderedListItem>
-            <Link href="https://nl-design-system.github.io/denhaag/"> Den Haag Design System</Link>: begeleiding van het
-            design system team, en leveranciers begeleiden met open source bouwen volgens de NL Design System
-            architectuur.
-          </UnorderedListItem>
-
-          <UnorderedListItem>
-            <Link href="https://pki.utrecht.nl/">Digitaal Loket van gemeente Utrecht</Link>: ontwikkeling van Strapi CMS
-            voor de Producten en Diensten Catalogus, en de nieuwe website ontwikkelen als headless frontend op basis van
-            NL Design System. Dit project wordt in de loop van 2024 zichtbaar op utrecht.nl.
-          </UnorderedListItem>
-
-          <UnorderedListItem>
-            Huwelijksplanner voor gemeente Utrecht: front-end ontwikkeling Huwelijksplanner CMS op basis van NL Design
-            System componenten.
-          </UnorderedListItem>
-
-          <UnorderedListItem>
-            <Link href="https://gemeentevoorbeeld.nl/">gemeente Voorbeeld</Link>: ontwikkeling van demo-website waar
-            Vereniging van Nederlandse Gemeenten (VNG) gebruikerstesten doet, om gemeenten op weg te helpen met voldoen
-            aan de&#160;
-            <Link href="https://www.digitaleoverheid.nl/overzicht-van-alle-onderwerpen/wetgeving/wet-modernisering-elektronisch-bestuurlijk-verkeer/">
-              WMEBV
-            </Link>
-            &#160;met NL Design System.
-          </UnorderedListItem>
-
-          <UnorderedListItem>
-            <Link href="https://opencatalogi.nl/">OpenCatalogi.nl — migratie naar NL Design System</Link>: migratie van
-            codebase naar React componenten uit de NL Design System community.
-          </UnorderedListItem>
-
-          <UnorderedListItem>
-            <Link href="https://opencatalogi.nl/">Huisstijl van gemeente Rotterdam voor OpenCatalogi.nl</Link>:
-            ontwikkeling van NL Design System thema zodat OpenCatalogi kan overstappen op NL Design System.
-          </UnorderedListItem>
-        </UnorderedList>
-      </section>
-    </div>
+      </PageContent>
+    </Page>
   ),
 };

--- a/proprietary/design-tokens/figma/figma.tokens.json
+++ b/proprietary/design-tokens/figma/figma.tokens.json
@@ -1071,6 +1071,18 @@
           }
         }
       }
+    },
+    "frameless": {
+      "rich-text": { "max-inline-size": { "value": "800px" } }
+    }
+  },
+  "components/page": {
+    "utrecht": {
+      "page": {
+        "max-inline-size": { "value": "{frameless.rich-text.max-inline-size}" },
+        "margin-block-end": { "value": "{frameless.space.block.cat}" },
+        "margin-block-start": { "value": "{frameless.space.block.cat}" }
+      }
     }
   },
   "components/accordion": {


### PR DESCRIPTION
# Refactor/storybook homepage template styling

## What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

* layout styling voor de homepage template story in Storybook
* toevoeging van page tokens in json
* placeholders vervangen door de juiste componenten (Card, CardGroup, Logo)
* toevoeging Page, PageContent components (for max-inline-size Paragraph + centreren content op groot scherm)
