### PR TITLE
docs: improve <title> and <meta> content

### DIFF
--- a/apps/next.frameless.io/src/index.html
+++ b/apps/next.frameless.io/src/index.html
@@ -4,7 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="./index.css" />
-    <title>Next Frameless Website</title>
+    <title>Frameless — experts in samenwerken aan websites</title>
+    <meta
+      name="description"
+      content="Wij maken maatwerk websites met een CMS, een design system, gebruikersonderzoek en een toegankelijkheidsverklaring. Maak een afspraak om kennis te maken!"
+    />
+    <meta
+      name="keywords"
+      content="NL Design System, toegankelijkheidsverklaring, Strapi, headless CMS, design system, front-end"
+    />
   </head>
   <body class="frameless-theme">
     <div class="utrecht-document utrecht-document--surface">


### PR DESCRIPTION
For search engines, we need to have good content for:

- [x] page `<title>`
- [x] meta description
- [x] keywords